### PR TITLE
fix: bump napi to 3.10.5 (FunctionRef off-thread-drop fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ lzma-rust2 = { version = "0.16", default-features = false, features = [
   "xz",
   "optimization",
 ] }
-napi = "3"
+napi = "3.10.5"
 napi-derive = "3"
 
 # The Web Streams transforms (`src/stream_web.rs`) need tokio + tokio-stream via
@@ -25,7 +25,7 @@ napi-derive = "3"
 # `napi_add_finalizer` (Node-API 5), so `napi5` is required alongside it. All
 # supported Node engines (^22.20 || ^24.12 || >=25) ship Node-API 9+.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-napi = { version = "3", features = ["web_stream", "napi5"] }
+napi = { version = "3.10.5", features = ["web_stream", "napi5"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_arch = "arm"), not(target_arch = "x86"), not(target_family = "wasm")))'.dependencies]
 mimalloc-safe = { version = "0.1", features = ["skip_collect_on_exit"] }


### PR DESCRIPTION
## Why

The flaky CI SIGSEGV/SIGBUS in `streaming-robustness.spec.ts` (e.g. [this run](https://github.com/Brooooooklyn/lzma/actions/runs/29220778646/job/86726098686)) was **heap corruption**, not a flaky test.

The Web Streams transforms forward codec failures as `Err` items, so every garbage / truncated / errored-input case makes the output `ReadableStream` **reject**. napi then dropped the pull resolver — which owns the controller's `enqueue`/`close` `FunctionRef`s — on a Tokio worker thread, and `FunctionRef::drop` deleted those **thread-affine** `napi_ref`s off the JS thread, corrupting V8's `GlobalHandles`. The fault surfaced later on the JS thread as SIGSEGV/SIGBUS — hence flaky, and hitting both macOS (SIGBUS) and Linux (SIGSEGV).

Root-caused and fixed upstream in **napi-rs/napi-rs#3394**, released in **napi 3.10.5**.

## What

Bump `napi` to `3.10.5`. Verified: the previously ~100%-crashing `streaming-robustness` suite is **0 crashes / 8 runs** on the 3.10.5 build (release, mimalloc on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version pin with no application code changes; reduces crash risk in streaming paths.
> 
> **Overview**
> Pins **`napi`** from **`3`** to **`3.10.5`** in both the default dependency and the non-wasm target block (still with **`web_stream`** and **`napi5`**).
> 
> This pulls in **napi-rs/napi-rs#3394**, which stops **`FunctionRef`** / pull-resolver teardown from deleting thread-affine **`napi_ref`s** on Tokio worker threads when Web Streams transforms reject—behavior that was corrupting V8 **`GlobalHandles`** and showing up as flaky **SIGSEGV/SIGBUS** in **`streaming-robustness`** tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5565ec4b423797cc475f4a32540be02eb89d8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->