### PR TITLE
docs(ci): document known QEMU-emulation SIGSEGV flakiness on emulated legs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -391,6 +391,17 @@ jobs:
         with:
           platforms: all
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      # These non-x86_64 legs run the target binary under QEMU user-mode emulation,
+      # which flakily SIGSEGVs INDEPENDENTLY of our code: native runs are clean, and
+      # the crash can fire before any test even starts (a bare `Segmentation fault
+      # (core dumped)`). This is long-standing QEMU instability (observed on ~2/3 of
+      # main runs since 2026-05), not a regression. s390x + ppc64le are the worst
+      # offenders (they segfault in almost every run), so they are `continue-on-error`
+      # below to keep that noise from failing CI; the little/large-endian coverage they
+      # still provide when they DO pass is the point. aarch64/armv7 are far more stable
+      # and are left as hard gates — aarch64 reds only ~1/112 jobs, so just re-run it.
+      # (A genuine, reproducible-everywhere crash — e.g. the napi FunctionRef off-thread
+      # drop fixed in napi 3.10.5 — would fail native legs too, not just these.)
       - name: Test bindings
         uses: addnab/docker-run-action@v3
         continue-on-error: ${{ contains(matrix.target, 'powerpc64') || contains(matrix.target, 's390x') }}


### PR DESCRIPTION
## Context

After the napi 3.10.5 bump (#388) fixed the reproducible Web-Streams heap-corruption crash, a `lzma2.spec.ts` SIGSEGV surfaced on **Test aarch64-unknown-linux-gnu - node@22**. Investigation showed this is a **different, long-standing issue**, not a regression:

- The non-x86_64 `test-linux-binding` legs run under **QEMU user-mode emulation**, which flakily SIGSEGVs independently of our code. Native runs are clean (verified 40/40 on aarch64-darwin), and the crash can fire **before any test even starts** (a bare `Segmentation fault (core dumped)`).
- It's been happening on **~2/3 of `main` runs since 2026-05** — dominant on **s390x/ppc64le** (which crash in nearly every run) but **masked** by their `continue-on-error`. **aarch64** is the one emulated leg that isn't masked, so its rare crash (~**1 in 112** jobs) turns the build red.

## Change

Documentation only — a comment near the emulated `Test bindings` step so a future red build on aarch64 (or a masked s390x/ppc64le segfault) is recognised as emulator noise rather than re-investigated as a regression. **No behavioural change.**

Decision: leave the emulated-leg flakiness as-is (re-run CI on the rare red build); the genuinely-fixed, reproducible-everywhere crash was the separate napi FunctionRef off-thread drop shipped in napi 3.10.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in CI workflow; no test, build, or publish logic is modified.
> 
> **Overview**
> Adds an inline comment in **`.github/workflows/CI.yml`** before the emulated **`Test bindings`** step in **`test-linux-binding`**, explaining why non-x86_64 matrix legs can fail with QEMU user-mode **SIGSEGV** noise that is unrelated to project code.
> 
> The comment clarifies that **s390x** and **ppc64le** are already allowed to fail via existing **`continue-on-error`**, while **aarch64**/**armv7** remain hard gates, and how to distinguish emulator flakiness from a real cross-platform regression (e.g. one that also fails on native legs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19f576ae4f8c0306a00edfbae572f917de363eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->