### PR TITLE
ci: run aarch64 tests on native arm64 runners instead of QEMU

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -342,7 +342,11 @@ jobs:
         exclude:
           - target: armv7-unknown-linux-gnueabihf
             node: '24'
-    runs-on: ubuntu-latest
+    # aarch64 runs on GitHub's native arm64 runner so its docker tests execute
+    # NATIVELY instead of under QEMU user-mode emulation — which flakily SIGSEGVs
+    # independently of our code. The other non-x86_64 targets (armv7/ppc64le/s390x)
+    # have no native runner, so they stay on x86_64 + QEMU (below).
+    runs-on: ${{ contains(matrix.target, 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup node
@@ -386,13 +390,22 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
+      # QEMU is only needed to emulate a foreign arch on the x86_64 host. aarch64
+      # runs on a native arm64 runner (`--platform linux/arm64` is native there),
+      # so skip the emulation setup for it.
       - name: Set up QEMU
+        if: ${{ !contains(matrix.target, 'aarch64') }}
         uses: docker/setup-qemu-action@v4
         with:
           platforms: all
-      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - if: ${{ !contains(matrix.target, 'aarch64') }}
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Test bindings
         uses: addnab/docker-run-action@v3
+        # powerpc64le/s390x still run under QEMU and flakily SIGSEGV independently of
+        # our code (long-standing emulator instability — sometimes crashing before a
+        # test even starts), so they are continue-on-error to keep that noise out of
+        # CI while preserving the endianness coverage they give when they pass.
         continue-on-error: ${{ contains(matrix.target, 'powerpc64') || contains(matrix.target, 's390x') }}
         with:
           image: ${{ steps.docker.outputs.IMAGE }}


### PR DESCRIPTION
## Why

The `aarch64-unknown-linux-{gnu,musl}` test legs ran their target docker image under **QEMU user-mode emulation** on an x86_64 host. QEMU flakily SIGSEGVs independently of our code — native runs are clean (verified 40/40 on aarch64-darwin), and it can crash *before a test even starts*. That's what turned a recent `main` build red on `Test aarch64-unknown-linux-gnu - node@22` (`lzma2.spec.ts exited due to SIGSEGV`).

## What

Run the aarch64 legs on GitHub's **native arm64 runner** (`ubuntu-24.04-arm`), so `--platform linux/arm64` executes natively — no emulation, no QEMU segfaults:

```
target                     runs-on            QEMU
x86_64-gnu / musl          ubuntu-latest      no   (native amd64)
aarch64-gnu / musl         ubuntu-24.04-arm   NO   ← was x86_64 + QEMU
armv7 / ppc64le / s390x    ubuntu-latest      yes  (no native runner)
```

- Conditional `runs-on` picks the arm runner for aarch64 targets.
- QEMU setup steps are skipped for aarch64 (unnecessary on a native arm host).
- `armv7`/`ppc64le`/`s390x` still run under QEMU; `ppc64le`/`s390x` stay `continue-on-error` for the same long-standing emulator flakiness (now documented inline).

Supersedes #389 (which documented the aarch64 flakiness as leave-as-is; this fixes it at the source instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to runner selection and QEMU gating; no product code, auth, or release logic touched.
> 
> **Overview**
> Fixes flaky **aarch64** Linux binding test legs that were failing with QEMU user-mode **SIGSEGV** on `ubuntu-latest` by running those matrix rows on **`ubuntu-24.04-arm`**, so `linux/arm64` Docker tests execute natively.
> 
> **QEMU** setup (`docker/setup-qemu-action` and `multiarch/qemu-user-static`) is now **skipped** when `matrix.target` contains `aarch64`. **armv7**, **powerpc64le**, and **s390x** still use x86_64 hosts with QEMU.
> 
> The **Test bindings** step gets **`continue-on-error`** for **powerpc64le** and **s390x**, with inline comments explaining ongoing emulator instability while keeping endianness coverage when runs succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1cbfc570e51b87d47ddb554b03d012aa6725d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->