### PR TITLE
fix(ci): rm x64 host helper after cross builds so it can't clobber the published binary

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,11 +118,17 @@ jobs:
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             setup: wget https://www.unpkg.com/@napi-rs/lzma-linux-x64-gnu/lzma.linux-x64-gnu.node
-            build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
+            build: |
+              yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
+              # Drop the x64 host helper so the `lzma.*.node` upload glob does not
+              # ship a stale x64 binary that clobbers the real one at publish time.
+              rm lzma.linux-x64-gnu.node
           - host: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
             setup: wget https://www.unpkg.com/@napi-rs/lzma-linux-x64-gnu/lzma.linux-x64-gnu.node
-            build: yarn build --target armv7-unknown-linux-gnueabihf --use-napi-cross
+            build: |
+              yarn build --target armv7-unknown-linux-gnueabihf --use-napi-cross
+              rm lzma.linux-x64-gnu.node
           - host: ubuntu-latest
             target: aarch64-linux-android
             build: yarn build --target aarch64-linux-android
@@ -143,6 +149,7 @@ jobs:
             build: |
               wget https://www.unpkg.com/@napi-rs/lzma-linux-x64-gnu/lzma.linux-x64-gnu.node
               CC=clang yarn build --target powerpc64le-unknown-linux-gnu --use-napi-cross
+              rm lzma.linux-x64-gnu.node
           - host: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: |
@@ -150,6 +157,7 @@ jobs:
               export CC=clang
               export CFLAGS="-fuse-ld=lld"
               yarn build --target s390x-unknown-linux-gnu --use-napi-cross
+              rm lzma.linux-x64-gnu.node
           - host: ubuntu-latest
             target: 'riscv64gc-unknown-linux-gnu'
             setup: |


### PR DESCRIPTION
Fixes the root cause behind #276 (`Decompressor is not a constructor` on x64 Linux).

## What users hit

On glibc **x64** Linux, `@napi-rs/lzma@1.5.0`:

```js
import { createDecompressStream } from '@napi-rs/lzma/xz'
createDecompressStream()   // → TypeError: Decompressor is not a constructor
```

Reproduced in Docker (`--platform linux/amd64`, `node:22-slim`):

```
raw.XzDecompressor:       undefined     ← streaming class missing
raw.xz.decompressStream:  undefined     ← web-stream fn missing
→ createStreamApi falls back to `new Decompressor()` → not a constructor
```
arm64/mac/windows are fine.

## Root cause (verified byte-for-byte)

The published **`linux-x64-gnu@1.5.0` binary is byte-identical to `1.4.5`** — i.e. it predates the streaming feature (#378):

```
sha256  lzma-linux-x64-gnu@1.5.0  fff36a96…  ┐ identical
sha256  lzma-linux-x64-gnu@1.4.5  fff36a96…  ┘
sha256  lzma-linux-arm64-gnu@1.5.0 cfc54b21… (has streaming)

strings | grep -c decompressStream:  x64@1.5.0 = 0   arm64@1.5.0 = 1
```

Why: the cross-compiled gnu targets (`aarch64`, `armv7`, `ppc64le`, `s390x`) `wget` the previously-published `lzma.linux-x64-gnu.node` as a **host helper** for napi codegen, but never delete it. The upload step globs `lzma.*.node`, so each of those jobs ships a **stale x64 binary** next to its own — the aarch64 job log literally says *"there will be 2 files uploaded"*. At publish, `napi artifacts` lets one of those stale copies overwrite the freshly-built x64 binary.

The x64-gnu build job itself built a correct binary; it just got clobbered at publish time. This is why the release CI was all-green: the fresh binary passed its own tests, and the clobber only happened in `Publish`.

```
cross job: wget x64@1.4.5 helper → build own target → upload lzma.*.node  (2 files: own + stale x64)
                                                                    │
Publish: napi artifacts merges all artifacts → stale x64 wins → published as 1.5.0
```

## Fix

`rm lzma.linux-x64-gnu.node` at the end of each cross build that fetches it — the canonical napi-rs template pattern (e.g. `napi-rs/tar`'s CI already does `rm tar.linux-x64-gnu.node`). This was simply missing here, and adding new cross targets without it is how the stale copy leaked in.

## ⚠️ Follow-up required

This CI fix stops it recurring, but npm packages are immutable — **a `1.5.1` release is needed** to actually ship a correct `linux-x64-gnu` binary to affected users.

Optional hardening (not in this PR): a publish-time assertion that each `npm/<target>/*.node` contains the expected streaming symbols, and/or a clearer runtime error than "not a constructor" when a mismatched binary is loaded.

Refs #276
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only packaging fix with no runtime or application code changes; wrong removal would only affect build artifacts for those matrix legs.
> 
> **Overview**
> Cross-compiled Linux GNU matrix jobs that **wget** `lzma.linux-x64-gnu.node` as an napi host helper now **delete that file** after `yarn build`, so artifact uploads matching `lzma.*.node` only include the target binary.
> 
> Affected targets: **aarch64-unknown-linux-gnu**, **armv7-unknown-linux-gnueabihf**, **powerpc64le-unknown-linux-gnu**, and **s390x-unknown-linux-gnu**. Build steps were expanded to multi-line shell blocks with an inline comment on aarch64 explaining the publish-time overwrite issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d596a280a38bd483030e1096ae2d458cb8c558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->